### PR TITLE
Locking down deleting a list to the owner of the list.

### DIFF
--- a/api/api/alist.go
+++ b/api/api/alist.go
@@ -107,9 +107,17 @@ func (env *Env) RemoveAlist(c echo.Context) error {
 
 	err := env.Datastore.RemoveAlist(alist_uuid, user.Uuid)
 	if err != nil {
-		if err.Error() != i18n.InputDeleteAlistOperationOwnerOnly {
-			response.Message = i18n.InternalServerErrorDeleteAlist
+		if err.Error() == i18n.SuccessAlistNotFound {
+			response.Message = err.Error()
+			return c.JSON(http.StatusNotFound, response)
 		}
+
+		if err.Error() == i18n.InputDeleteAlistOperationOwnerOnly {
+			response.Message = err.Error()
+			return c.JSON(http.StatusForbidden, response)
+		}
+
+		response.Message = i18n.InternalServerErrorDeleteAlist
 		return c.JSON(http.StatusInternalServerError, response)
 	}
 

--- a/api/api/alist.go
+++ b/api/api/alist.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/freshteapot/learnalist-api/api/alist"
+	"github.com/freshteapot/learnalist-api/api/i18n"
 	"github.com/freshteapot/learnalist-api/api/uuid"
 	"github.com/labstack/echo/v4"
 )
@@ -31,7 +32,7 @@ func (env *Env) GetListByUUID(c echo.Context) error {
 	uuid := strings.TrimPrefix(r.URL.Path, "/alist/")
 	if uuid == "" {
 		response := HttpResponseMessage{
-			Message: InputMissingListUuid,
+			Message: i18n.InputMissingListUuid,
 		}
 		return c.JSON(http.StatusNotFound, response)
 	}
@@ -97,21 +98,21 @@ func (env *Env) SaveAlist(c echo.Context) error {
 }
 
 func (env *Env) RemoveAlist(c echo.Context) error {
-	var message string
 	r := c.Request()
 	// TODO Reference https://github.com/freshteapot/learnalist-api/issues/22
 	alist_uuid := strings.TrimPrefix(r.URL.Path, "/alist/")
 
 	user := c.Get("loggedInUser").(uuid.User)
-
-	err := env.Datastore.RemoveAlist(alist_uuid, user.Uuid)
 	response := HttpResponseMessage{}
 
-	message = fmt.Sprintf("List %s was removed.", alist_uuid)
+	err := env.Datastore.RemoveAlist(alist_uuid, user.Uuid)
 	if err != nil {
-		response.Message = InternalServerErrorDeleteAlist
+		if err.Error() != i18n.InputDeleteAlistOperationOwnerOnly {
+			response.Message = i18n.InternalServerErrorDeleteAlist
+		}
 		return c.JSON(http.StatusInternalServerError, response)
 	}
-	response.Message = message
+
+	response.Message = fmt.Sprintf("List %s was removed.", alist_uuid)
 	return c.JSON(http.StatusOK, response)
 }

--- a/api/api/alist.go
+++ b/api/api/alist.go
@@ -103,6 +103,7 @@ func (env *Env) RemoveAlist(c echo.Context) error {
 	alist_uuid := strings.TrimPrefix(r.URL.Path, "/alist/")
 
 	user := c.Get("loggedInUser").(uuid.User)
+
 	err := env.Datastore.RemoveAlist(alist_uuid, user.Uuid)
 	response := HttpResponseMessage{}
 

--- a/api/api/alist.go
+++ b/api/api/alist.go
@@ -38,7 +38,7 @@ func (env *Env) GetListByUUID(c echo.Context) error {
 	}
 	alist, err := env.Datastore.GetAlist(uuid)
 	if err != nil {
-		message := fmt.Sprintf("Failed to find alist with uuid: %s", uuid)
+		message := fmt.Sprintf(i18n.ApiAlistNotFound, uuid)
 		response := HttpResponseMessage{
 			Message: message,
 		}
@@ -60,7 +60,7 @@ func (env *Env) SaveAlist(c echo.Context) error {
 		inputUuid = strings.TrimPrefix(r.URL.Path, "/alist/")
 	} else {
 		response := HttpResponseMessage{
-			Message: "This method is not supported.",
+			Message: i18n.ApiMethodNotSupported,
 		}
 		return c.JSON(http.StatusBadRequest, response)
 	}
@@ -113,6 +113,6 @@ func (env *Env) RemoveAlist(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, response)
 	}
 
-	response.Message = fmt.Sprintf("List %s was removed.", alist_uuid)
+	response.Message = fmt.Sprintf(i18n.ApiDeleteAlistSuccess, alist_uuid)
 	return c.JSON(http.StatusOK, response)
 }

--- a/api/api/doc.go
+++ b/api/api/doc.go
@@ -1,8 +1,1 @@
 package api
-
-const (
-	DeleteUserLabelSuccess         = "Label %s was removed."
-	PostUserLabelJSONFailure       = "Your input is invalid json."
-	InputMissingListUuid           = "The uuid is missing."
-	InternalServerErrorDeleteAlist = "We have failed to remove your list."
-)

--- a/api/api/label.go
+++ b/api/api/label.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/freshteapot/learnalist-api/api/i18n"
 	"github.com/freshteapot/learnalist-api/api/models"
 	"github.com/freshteapot/learnalist-api/api/uuid"
 	"github.com/labstack/echo/v4"
@@ -26,7 +27,7 @@ func (env *Env) PostUserLabel(c echo.Context) error {
 	err := json.Unmarshal(jsonBytes, input)
 	if err != nil {
 		response := HttpResponseMessage{
-			Message: PostUserLabelJSONFailure,
+			Message: i18n.PostUserLabelJSONFailure,
 		}
 		return c.JSON(http.StatusBadRequest, response)
 	}
@@ -70,6 +71,6 @@ func (env *Env) RemoveUserLabel(c echo.Context) error {
 		response.Message = err.Error()
 		return c.JSON(http.StatusInternalServerError, response)
 	}
-	response.Message = fmt.Sprintf(DeleteUserLabelSuccess, label)
+	response.Message = fmt.Sprintf(i18n.DeleteUserLabelSuccess, label)
 	return c.JSON(http.StatusOK, response)
 }

--- a/api/api/label.go
+++ b/api/api/label.go
@@ -71,6 +71,6 @@ func (env *Env) RemoveUserLabel(c echo.Context) error {
 		response.Message = err.Error()
 		return c.JSON(http.StatusInternalServerError, response)
 	}
-	response.Message = fmt.Sprintf(i18n.DeleteUserLabelSuccess, label)
+	response.Message = fmt.Sprintf(i18n.ApiDeleteUserLabelSuccess, label)
 	return c.JSON(http.StatusOK, response)
 }

--- a/api/i18n/doc.go
+++ b/api/i18n/doc.go
@@ -8,8 +8,11 @@ const (
 	InternalServerErrorMissingUserUuid   = "User.Uuid is missing, possibly an internal error"
 	InternalServerErrorTalkingToDatabase = "Issue with talking to the database in %s."
 	InputDeleteAlistOperationOwnerOnly   = "Only the owner of the list can remove it."
-	DeleteUserLabelSuccess               = "Label %s was removed."
 	PostUserLabelJSONFailure             = "Your input is invalid json."
 	InputMissingListUuid                 = "The uuid is missing."
 	InternalServerErrorDeleteAlist       = "We have failed to remove your list."
+	ApiMethodNotSupported                = "This method is not supported."
+	ApiAlistNotFound                     = "Failed to find alist with uuid: %s"
+	ApiDeleteAlistSuccess                = "List %s was removed."
+	ApiDeleteUserLabelSuccess            = "Label %s was removed."
 )

--- a/api/i18n/doc.go
+++ b/api/i18n/doc.go
@@ -1,0 +1,15 @@
+package i18n
+
+const (
+	ValidationWarningLabelToLong         = "The label cannot be longer than 20 characters."
+	ValidationWarningLabelNotEmpty       = "The label cannot be empty."
+	SuccessAlistNotFound                 = "List not found."
+	InternalServerErrorMissingAlistUuid  = "Uuid is missing, possibly an internal error"
+	InternalServerErrorMissingUserUuid   = "User.Uuid is missing, possibly an internal error"
+	InternalServerErrorTalkingToDatabase = "Issue with talking to the database in %s."
+	InputDeleteAlistOperationOwnerOnly   = "Only the owner of the list can remove it."
+	DeleteUserLabelSuccess               = "Label %s was removed."
+	PostUserLabelJSONFailure             = "Your input is invalid json."
+	InputMissingListUuid                 = "The uuid is missing."
+	InternalServerErrorDeleteAlist       = "We have failed to remove your list."
+)

--- a/api/models/alist.go
+++ b/api/models/alist.go
@@ -108,7 +108,11 @@ func (dal *DAL) GetAlist(uuid string) (*alist.Alist, error) {
 
 func (dal *DAL) RemoveAlist(alist_uuid string, user_uuid string) error {
 
-	aList, _ := dal.GetAlist(alist_uuid)
+	aList, err := dal.GetAlist(alist_uuid)
+
+	if err != nil {
+		return err
+	}
 
 	if aList.User.Uuid != user_uuid {
 		return errors.New(i18n.InputDeleteAlistOperationOwnerOnly)
@@ -126,7 +130,7 @@ AND
 `
 	tx := dal.Db.MustBegin()
 	tx.MustExec(query, alist_uuid, user_uuid)
-	err := tx.Commit()
+	err = tx.Commit()
 	if err != nil {
 		log.Println(fmt.Sprintf(i18n.InternalServerErrorTalkingToDatabase, "RemoveAlist"))
 		log.Println(err)

--- a/api/models/alist_test.go
+++ b/api/models/alist_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/freshteapot/learnalist-api/api/alist"
+	"github.com/freshteapot/learnalist-api/api/i18n"
 	"github.com/freshteapot/learnalist-api/api/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -53,12 +54,12 @@ INSERT INTO user VALUES('7540fe5f-9847-5473-bdbd-2b20050da0c6','A904605244475255
 	// Check empty alist.uuid
 	aList.Uuid = ""
 	err = dal.SaveAlist(*aList)
-	assert.Equal(t, InternalServerErrorMissingAlistUuid, err.Error())
+	assert.Equal(t, i18n.InternalServerErrorMissingAlistUuid, err.Error())
 	aList.Uuid = alist_uuid
 	// Check empty user.uuid
 	aList.User.Uuid = ""
 	err = dal.SaveAlist(*aList)
-	assert.Equal(t, InternalServerErrorMissingUserUuid, err.Error())
+	assert.Equal(t, i18n.InternalServerErrorMissingUserUuid, err.Error())
 }
 
 func TestRemoveLabelsForAlistEmptyUuid(t *testing.T) {
@@ -82,9 +83,16 @@ INSERT INTO alist_labels VALUES('ada41576-b710-593a-9603-946aaadcb22d','7540fe5f
 
 	aList, _ := dal.GetAlist(alist_uuid)
 	assert.Equal(t, alist.SimpleList, aList.Info.ListType)
-	dal.RemoveAlist(alist_uuid, user_uuid)
-	_, err := dal.GetAlist(alist_uuid)
-	assert.Equal(t, SuccessAlistNotFound, err.Error())
+
+	// Check removing a list of a different user.
+	err := dal.RemoveAlist(alist_uuid, "fake")
+	assert.Equal(t, i18n.InputDeleteAlistOperationOwnerOnly, err.Error())
+
+	// Check removing a list owned by the user
+	err = dal.RemoveAlist(alist_uuid, user_uuid)
+	assert.Nil(t, err)
+	_, err = dal.GetAlist(alist_uuid)
+	assert.Equal(t, i18n.SuccessAlistNotFound, err.Error())
 }
 
 func TestGetListsByUserAndLabels(t *testing.T) {

--- a/api/models/label.go
+++ b/api/models/label.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+
+	"github.com/freshteapot/learnalist-api/api/i18n"
 )
 
 type UserLabel struct {
@@ -36,11 +38,11 @@ func NewAlistLabel(label string, user string, alist string) *AlistLabel {
 
 func ValidateLabel(label string) error {
 	if label == "" {
-		return errors.New(ValidationWarningLabelNotEmpty)
+		return errors.New(i18n.ValidationWarningLabelNotEmpty)
 	}
 
 	if len(label) > 20 {
-		return errors.New(ValidationWarningLabelToLong)
+		return errors.New(i18n.ValidationWarningLabelToLong)
 	}
 	return nil
 }

--- a/api/models/label_test.go
+++ b/api/models/label_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/freshteapot/learnalist-api/api/i18n"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,12 +27,12 @@ func TestPostUserLabel(t *testing.T) {
 	b := NewUserLabel("label_123456789_123456789_car_boat", "user2")
 	statusCode, err = dal.PostUserLabel(b)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
-	assert.Equal(t, ValidationWarningLabelToLong, err.Error())
+	assert.Equal(t, i18n.ValidationWarningLabelToLong, err.Error())
 
 	c := NewUserLabel("", "user2")
 	statusCode, err = dal.PostUserLabel(c)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
-	assert.Equal(t, ValidationWarningLabelNotEmpty, err.Error())
+	assert.Equal(t, i18n.ValidationWarningLabelNotEmpty, err.Error())
 }
 
 func TestPostAlistLabel(t *testing.T) {
@@ -46,7 +47,7 @@ func TestPostAlistLabel(t *testing.T) {
 	b := NewAlistLabel("label_123456789_123456789_car_boat", "u:123", "u:456")
 	statusCode, err := dal.PostAlistLabel(b)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
-	assert.Equal(t, ValidationWarningLabelToLong, err.Error())
+	assert.Equal(t, i18n.ValidationWarningLabelToLong, err.Error())
 }
 
 func TestGetUserLabels(t *testing.T) {

--- a/api/models/struct.go
+++ b/api/models/struct.go
@@ -1,14 +1,5 @@
 package models
 
-const (
-	ValidationWarningLabelToLong         = "The label cannot be longer than 20 characters."
-	ValidationWarningLabelNotEmpty       = "The label cannot be empty."
-	SuccessAlistNotFound                 = "List not found."
-	InternalServerErrorMissingAlistUuid  = "Uuid is missing, possibly an internal error"
-	InternalServerErrorMissingUserUuid   = "User.Uuid is missing, possibly an internal error"
-	InternalServerErrorTalkingToDatabase = "Issue with talking to the database in %s."
-)
-
 type SimpleEvent struct {
 	What     string `db:"what"`
 	WhatUuid string `db:"what_uuid"`


### PR DESCRIPTION
Should fix #21.

# How to test

Create two users
```sh
curl -s -w "%{http_code}\n" -XPOST 127.0.0.1:1234/register -d'
{
    "username":"test1",
    "password":"test"
}
'
curl -s -w "%{http_code}\n" -XPOST 127.0.0.1:1234/register -d'
{
    "username":"test2",
    "password":"test"
}
'
```

Create a list
```sh
curl -s -w "%{http_code}\n" -XPOST  http://127.0.0.1:1234/alist -u'test1:test' -d'
{
    "data": ["car"],
    "info": {
        "title": "Days of the Week",
        "type": "v1"
    }
}'
```

Try deleting the list via the other user, confirm it responds with a 403.
```sh
curl -s  -XGET http://127.0.0.1:1234/alist/by/me -u'test1:test' | \
jq -r '.[] | .uuid' | \
awk '{cmd="curl -s -w \"%{http_code}\\n\" -XDELETE http://127.0.0.1:1234/alist/"$1" -u'test2:test'";print(cmd);system(cmd)}'
```
```sh
{"message":"Only the owner of the list can remove it."}
403
```

Confirm 404 returns from trying to delete a list that doesnt exist.
```sh
curl -s -w "%{http_code}\n" -XDELETE http://127.0.0.1:1234/alist/fakeuuid123 -u'test2:test'
```
```sh
{"message":"List not found."}
404
```