### PR TITLE
Bug / sharing not rebuilding

### DIFF
--- a/server/alists/server/server_get_alist.go
+++ b/server/alists/server/server_get_alist.go
@@ -48,12 +48,6 @@ func (m *Manager) GetAlist(c echo.Context) error {
 		return c.File(pathToAlist)
 	}
 
-	// Assumed it is a fast request (maybe e2e tests) so blindly trigger a new Build
-	// of any queued content.
-	// This is a really ugly hack :P
-	// The e2e client bubbled this up as I have the timeouts set stupidly low
-	go m.HugoHelper.ProcessContent()
-
 	data, _ := ioutil.ReadFile(fmt.Sprintf("%s/alists/please-refresh.html", m.SiteCacheFolder))
 	return c.HTMLBlob(http.StatusOK, data)
 }

--- a/server/api/alist/alist.go
+++ b/server/api/alist/alist.go
@@ -42,11 +42,10 @@ type InputAlist struct {
 
 // Alist the outer wrapping of a list.
 type Alist struct {
-	Uuid     string `json:"uuid"`
-	User     uuid.User
-	ListType string
-	Info     AlistInfo   `json:"info"`
-	Data     interface{} `json:"data"`
+	Uuid string `json:"uuid"`
+	User uuid.User
+	Info AlistInfo   `json:"info"`
+	Data interface{} `json:"data"`
 }
 
 // MarshalJSON convert alist into json

--- a/server/api/api/share.go
+++ b/server/api/api/share.go
@@ -39,7 +39,7 @@ func (m *Manager) V1ShareListReadAccess(c echo.Context) error {
 		}
 		return c.JSON(http.StatusBadRequest, response)
 	}
-	// TODO how do we know what the sharing is set too?
+
 	aList, err := m.Datastore.GetAlist(input.AlistUUID)
 	if err != nil {
 		if err.Error() == i18n.SuccessAlistNotFound {
@@ -53,6 +53,12 @@ func (m *Manager) V1ShareListReadAccess(c echo.Context) error {
 			Message: i18n.InternalServerErrorFunny,
 		}
 		return c.JSON(http.StatusInternalServerError, response)
+	}
+
+	if aList.Info.SharedWith == aclKeys.NotShared {
+		return c.JSON(http.StatusBadRequest, HttpResponseMessage{
+			Message: i18n.ApiShareReadAccessInvalidWithNotShared,
+		})
 	}
 
 	if aList.User.Uuid != user.Uuid {

--- a/server/api/api/share.go
+++ b/server/api/api/share.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -75,7 +74,6 @@ func (m *Manager) V1ShareListReadAccess(c echo.Context) error {
 		return c.JSON(http.StatusUnprocessableEntity, response)
 	}
 
-	fmt.Println(aList.Info.SharedWith)
 	if !m.Datastore.UserExists(input.UserUUID) {
 		response := HttpResponseMessage{
 			Message: i18n.SuccessUserNotFound,
@@ -122,8 +120,6 @@ func (m *Manager) V1ShareAlist(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, response)
 	}
 
-	// TODO how do we know what the sharing is set too?
-	// TODO we dont set it on change
 	aList, _ := m.Datastore.GetAlist(input.AlistUUID)
 	if aList == nil {
 		response := HttpResponseMessage{

--- a/server/api/i18n/doc.go
+++ b/server/api/i18n/doc.go
@@ -43,4 +43,5 @@ const (
 	ApiShareListSuccessWithPublic           = "List is now public"
 	ApiShareListSuccessWithFriends          = "List is now private to the owner and those granted access"
 	ApiShareListSuccessPrivate              = "List is now private to the owner"
+	ApiShareNoChange                        = "No change made"
 )

--- a/server/api/i18n/doc.go
+++ b/server/api/i18n/doc.go
@@ -43,5 +43,6 @@ const (
 	ApiShareListSuccessWithPublic           = "List is now public"
 	ApiShareListSuccessWithFriends          = "List is now private to the owner and those granted access"
 	ApiShareListSuccessPrivate              = "List is now private to the owner"
+	ApiShareReadAccessInvalidWithNotShared  = "You cant grant or revoke read access when the list is shared as private"
 	ApiShareNoChange                        = "No change made"
 )

--- a/server/api/models/alist.go
+++ b/server/api/models/alist.go
@@ -159,7 +159,6 @@ If empty user, we reject.
 If POST, we enforce a new uuid for the list.
 If empty uuid, we reject.
 If PUT, do a lookup to see if the list exists.
-
 */
 func (dal *DAL) SaveAlist(method string, aList alist.Alist) (*alist.Alist, error) {
 	var err error

--- a/server/e2e/client.go
+++ b/server/e2e/client.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -41,7 +42,7 @@ type Client struct {
 }
 
 func NewClient(_server string) Client {
-	timeout := 100 * time.Millisecond
+	timeout := 1 * time.Second
 	var netTransport = &http.Transport{
 		Dial: (&net.Dialer{
 			Timeout: timeout,
@@ -79,6 +80,7 @@ func (c Client) Register(username string, password string) RegisterResponse {
 
 	url := fmt.Sprintf("%s/api/v1/register", c.getServerURL())
 	req, err := http.NewRequest("POST", url, body)
+	req = req.WithContext(context.Background())
 	if err != nil {
 		// handle err
 		fmt.Println("Failed NewRequest")
@@ -116,6 +118,7 @@ func (c Client) RawPostListV1(userInfo RegisterResponse, input string) (*http.Re
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -149,6 +152,7 @@ func (c Client) RawPutListV1(userInfo RegisterResponse, uuid string, input strin
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -181,6 +185,7 @@ func (c Client) RawDeleteListV1(userInfo RegisterResponse, uuid string) (*http.R
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -199,6 +204,7 @@ func (c Client) SetListShareV1(userInfo RegisterResponse, alistUUID string, acti
 		// handle err
 		panic(err)
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -220,16 +226,20 @@ func (c Client) SetListShareV1(userInfo RegisterResponse, alistUUID string, acti
 
 func (c Client) GetListByUUIDV1(userInfo RegisterResponse, uuid string) HttpResponse {
 	url := fmt.Sprintf("%s/api/v1/alist/%s", c.getServerURL(), uuid)
+	fmt.Println("here")
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		// handle err
+
 		panic(err)
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		// handle err
+		fmt.Println("here")
 		panic(err)
 	}
 
@@ -256,6 +266,7 @@ func (c Client) RawPostLabelV1(userInfo RegisterResponse, label string) (*http.R
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -291,6 +302,7 @@ func (c Client) RawGetLabelsByMeV1(userInfo RegisterResponse) (*http.Response, e
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -326,6 +338,7 @@ func (c Client) RawDeleteLabelV1(userInfo RegisterResponse, label string) (*http
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -350,6 +363,7 @@ func (c Client) RawGetListsByMe(userInfo RegisterResponse, labels string, listTy
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -384,6 +398,7 @@ func (c Client) RawV1(userInfo RegisterResponse, method string, uri string, inpu
 		// handle err
 		return response, nil
 	}
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -400,6 +415,7 @@ func (c Client) GetAlistHtml(userInfo RegisterResponse, uuid string) (HttpRespon
 		return response, err
 	}
 
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpClient.Do(req)
@@ -435,6 +451,7 @@ func (c Client) ShareReadAcessV1(userInfo RegisterResponse, alistUUID string, us
 		return response, err
 	}
 
+	req = req.WithContext(context.Background())
 	req.Header.Set("Authorization", "Basic "+userInfo.BasicAuth)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpClient.Do(req)

--- a/server/e2e/smoke_list_access_test.go
+++ b/server/e2e/smoke_list_access_test.go
@@ -41,11 +41,9 @@ func TestListAccess(t *testing.T) {
 	assert.Equal(httpResponse.StatusCode, http.StatusOK)
 	assert.True(strings.Contains(string(httpResponse.Body), "Please refresh"))
 	fmt.Println(">> A human wait, should have contents")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(600 * time.Millisecond)
 
 	httpResponse, err = learnalistClient.GetAlistHtml(userInfoReader, aList.Uuid)
-	assert.NoError(err)
-	assert.Equal(httpResponse.StatusCode, http.StatusOK)
 	assert.NoError(err)
 	assert.Equal(httpResponse.StatusCode, http.StatusOK)
 	assert.True(strings.Contains(string(httpResponse.Body), "<title>Days of the Week</title>"))

--- a/server/pkg/acl/sqlite/sqlite.go
+++ b/server/pkg/acl/sqlite/sqlite.go
@@ -80,7 +80,6 @@ func (store *Sqlite) ShareListWithPublic(alistUUID string) error {
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, accessPublic)
 	if err != nil {
-		fmt.Println("He")
 		tx.Rollback()
 		return err
 	}

--- a/server/pkg/acl/sqlite/sqlite.go
+++ b/server/pkg/acl/sqlite/sqlite.go
@@ -62,26 +62,32 @@ func (store *Sqlite) ShareListWithPublic(alistUUID string) error {
 
 	tx, err := store.db.Beginx()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = tx.Exec(deleteViaAccess, accessPrivate)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = tx.Exec(deleteViaAccess, accessFriends)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, accessPublic)
 	if err != nil {
+		fmt.Println("He")
+		tx.Rollback()
 		return err
 	}
 
 	err = tx.Commit()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
@@ -95,31 +101,37 @@ func (store *Sqlite) MakeListPrivate(alistUUID string, userUUID string) error {
 
 	tx, err := store.db.Beginx()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = tx.Exec(deleteViaAlistUUID, alistUUID)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, read)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, owner)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, share)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	err = tx.Commit()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
@@ -138,26 +150,31 @@ func (store *Sqlite) ShareListWithFriends(alistUUID string) error {
 
 	tx, err := store.db.Beginx()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = tx.Exec(deleteViaAccess, accessPrivate)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = tx.Exec(deleteViaAccess, accessPublic)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	_, err = insertTX(tx, alistUUID, noUserUUUID, accessFriends)
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
 	err = tx.Commit()
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 


### PR DESCRIPTION
# Aim
- When sharing a list, trigger a rebuild for the html land.
- When sharing readaccess, make sure the list is not "private".

# Plus
- Discovered my code on transactions, was a bug waiting to happen. Thankfully the end to end testing caught it before it was committed :D 

# Todo
- [x] Make e2e tests happy
- [x] Add ginkgo tests to cover the new logic.
- [x] Ponder if I need the context stuff on httpclient