### PR TITLE
Adding created to spaced repetition

### DIFF
--- a/docs/install-onto-k8s.md
+++ b/docs/install-onto-k8s.md
@@ -52,7 +52,7 @@ kubectl scale deployment/container-registry  --replicas=1
 ```sh
 PATCH=$(cat <<_EOF_
   {"spec":{"template":{"metadata":{"creationTimestamp":"$(date -u '+%FT%TZ')"}}}}
-  _EOF_
+_EOF_
 )
 kubectl patch deployment learnalist -p "${PATCH}"
 ```
@@ -128,6 +128,7 @@ kill -9 $(lsof -ti tcp:5000)
 ssh $SSH_SERVER -L 6443:127.0.0.1:6443 -N &
 ssh $SSH_SERVER -L 5000:127.0.0.1:5000 -N &
 ```
+
 ```sh
 ssh $SSH_SERVER
 sudo su -
@@ -154,7 +155,7 @@ Patch if only bumped latest version
 ```sh
 PATCH=$(cat <<_EOF_
   {"spec":{"template":{"metadata":{"creationTimestamp":"$(date -u '+%FT%TZ')"}}}}
-  _EOF_
+_EOF_
 )
 kubectl patch deployment learnalist -p "${PATCH}"
 ```

--- a/docs/manual-db-update.md
+++ b/docs/manual-db-update.md
@@ -10,6 +10,9 @@
 ALTER TABLE spaced_repetition RENAME TO spaced_repetition_prev;
 ```
 
+# Create
+- take from db/202006271346-spaced-repetition.sql
+
 # Insert
 
 ```sql
@@ -21,3 +24,7 @@ FROM
   spaced_repetition_prev;
 ```
 
+
+```sql
+DROP TABLE spaced_repetition_prev;
+```

--- a/docs/manual-db-update.md
+++ b/docs/manual-db-update.md
@@ -1,0 +1,23 @@
+# Log of manual db updates
+- Installing from the start wont need these.
+
+## Updating db/202006271346-spaced-repetition.sql
+- Adding created column
+
+# Alter table
+
+```sql
+ALTER TABLE spaced_repetition RENAME TO spaced_repetition_prev;
+```
+
+# Insert
+
+```sql
+INSERT INTO
+  spaced_repetition (uuid, body, user_uuid, when_next)
+SELECT
+  uuid, body, user_uuid, when_next
+FROM
+  spaced_repetition_prev;
+```
+

--- a/docs/manual-db-update.md
+++ b/docs/manual-db-update.md
@@ -28,3 +28,43 @@ FROM
 ```sql
 DROP TABLE spaced_repetition_prev;
 ```
+
+# Manually update the data
+
+# Update the created first
+```sql
+UPDATE
+    spaced_repetition
+SET
+    body=json_patch(body, '{"settings": {"created": "' || strftime('%Y-%m-%dT%H:%M:%SZ', created) || '" }}'),
+    created=strftime('%Y-%m-%dT%H:%M:%SZ', created)
+WHERE
+    when_next NOT LIKE "%Z%";
+```
+
+# Update the when_next
+```sql
+UPDATE
+    spaced_repetition
+SET
+    body=json_patch(body, '{"settings": {"when_next": "' || strftime('%Y-%m-%dT%H:%M:%SZ', when_next) || '" }}'),
+    when_next=strftime('%Y-%m-%dT%H:%M:%SZ', when_next)
+WHERE
+    when_next NOT LIKE "%Z%";
+```
+
+
+# Diving into the data
+```sql
+SELECT
+    strftime('%Y-%m-%dT%H:%M:%SZ', t.when_next),
+    t.when_next,
+    json_patch(body, '{"settings": {"when_next": "' || strftime('%Y-%m-%dT%H:%M:%SZ', t.when_next) || '" }}'),
+    json_patch(body, '{"settings": {"created": "' || strftime('%Y-%m-%dT%H:%M:%SZ', t.created) || '" }}')
+FROM
+(
+    SELECT *  FROM spaced_repetition ORDER BY when_next ASC LIMIT 10
+) as t
+WHERE
+    t.when_next NOT LIKE "%Z%";
+```

--- a/openapi/api.spaced_repetition.yaml
+++ b/openapi/api.spaced_repetition.yaml
@@ -14,6 +14,7 @@ components:
           level: "0"
           show: "Hello"
           when_next: "2020-08-08T15:29:43Z"
+          created: "2020-08-08T14:29:43Z"
         uuid: "90d31f693a34558d0ba3702cc42b62ba670bc010"
     SpacedRepetitionInputV2:
       value:
@@ -35,6 +36,7 @@ components:
           level: "0"
           show: "from"
           when_next: "2020-08-08T15:29:43Z"
+          created: "2020-08-08T14:29:43Z"
         uuid: "90d31f693a34558d0ba3702cc42b62ba670bc010"
 
   schemas:
@@ -96,6 +98,11 @@ components:
         when_next:
           type: string
           format: date-time
+          description: Set to UTC
+        created:
+          type: string
+          format: date-time
+          description: Set to UTC
 
     SpacedRepetitionBaseSettingsShow:
       type: object

--- a/server/db/202006271346-spaced-repetition.sql
+++ b/server/db/202006271346-spaced-repetition.sql
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS spaced_repetition (
   uuid CHARACTER(36)  not null primary key,
   body text,
   user_uuid CHARACTER(36),
-  when_next DATETIME not null default (strftime('%Y-%m-%d %H:%M:%SZ', 'now')),
-  created DATETIME not null default (strftime('%Y-%m-%d %H:%M:%SZ', 'now')),
+  when_next DATETIME not null default (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  created DATETIME not null default (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
   UNIQUE(user_uuid, uuid)
 );
 

--- a/server/db/202006271346-spaced-repetition.sql
+++ b/server/db/202006271346-spaced-repetition.sql
@@ -2,7 +2,8 @@ CREATE TABLE IF NOT EXISTS spaced_repetition (
   uuid CHARACTER(36)  not null primary key,
   body text,
   user_uuid CHARACTER(36),
-  when_next DATETIME not null default (strftime('%s','now')),
+  when_next DATETIME not null default (strftime('%Y-%m-%d %H:%M:%SZ', 'now')),
+  created DATETIME not null default (strftime('%Y-%m-%d %H:%M:%SZ', 'now')),
   UNIQUE(user_uuid, uuid)
 );
 

--- a/server/pkg/spaced_repetition/doc.go
+++ b/server/pkg/spaced_repetition/doc.go
@@ -42,6 +42,7 @@ type HttpRequestInputV2Item struct {
 type HttpRequestInputSettings struct {
 	Level    string `json:"level"`
 	WhenNext string `json:"when_next"`
+	Created  string `json:"created"`
 }
 type HttpRequestInputSettingsV2 struct {
 	HttpRequestInputSettings
@@ -53,6 +54,7 @@ type SpacedRepetitionEntry struct {
 	Body     string    `db:"body"`
 	UserUUID string    `db:"user_uuid"`
 	WhenNext time.Time `db:"when_next"`
+	Created  time.Time `db:"created"`
 }
 
 const (
@@ -79,7 +81,7 @@ const (
 	THRESHOLD_8 = time.Duration(TIME_DAY * 60)
 	THRESHOLD_9 = time.Duration(TIME_DAY * 120)
 
-	SQL_SAVE_ITEM              = `INSERT INTO spaced_repetition(uuid, body, user_uuid, when_next) values(?, ?, ?, ?)`
+	SQL_SAVE_ITEM              = `INSERT INTO spaced_repetition(uuid, body, user_uuid, when_next, created) values(?, ?, ?, ?, ?)`
 	SQL_SAVE_ITEM_AUTO_UPDATED = `INSERT INTO spaced_repetition(uuid, body, user_uuid, when_next) values(?, ?, ?, ?) ON CONFLICT (spaced_repetition.user_uuid, spaced_repetition.uuid) DO UPDATE SET body=?, when_next=?`
 	SQL_DELETE_ITEM            = `DELETE FROM spaced_repetition WHERE uuid=? AND user_uuid=?`
 	SQL_GET_ITEM               = `SELECT * FROM spaced_repetition WHERE uuid=? AND user_uuid=?`
@@ -214,6 +216,7 @@ type ItemInput interface {
 	UUID() string
 	String() string
 	WhenNext() time.Time
+	Created() time.Time
 	IncrThreshold()
 	DecrThreshold()
 }

--- a/server/pkg/spaced_repetition/service.go
+++ b/server/pkg/spaced_repetition/service.go
@@ -59,6 +59,7 @@ func (s service) SaveEntry(c echo.Context) error {
 		UUID:     entry.UUID(),
 		Body:     entry.String(),
 		WhenNext: entry.WhenNext(),
+		Created:  entry.Created(),
 	}
 
 	err := s.repo.SaveEntry(item)

--- a/server/pkg/spaced_repetition/sqlite.go
+++ b/server/pkg/spaced_repetition/sqlite.go
@@ -78,7 +78,9 @@ func (r SqliteRepository) GetEntries(userUUID string) ([]interface{}, error) {
 }
 
 func (r SqliteRepository) SaveEntry(entry SpacedRepetitionEntry) error {
-	_, err := r.db.Exec(SQL_SAVE_ITEM, entry.UUID, entry.Body, entry.UserUUID, entry.WhenNext)
+	whenNext := entry.WhenNext.Format(time.RFC3339)
+	created := entry.Created.Format(time.RFC3339)
+	_, err := r.db.Exec(SQL_SAVE_ITEM, entry.UUID, entry.Body, entry.UserUUID, whenNext, created)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "UNIQUE constraint failed") {
 			return ErrSpacedRepetitionEntryExists
@@ -94,7 +96,8 @@ func (r SqliteRepository) DeleteEntry(userUUID string, UUID string) error {
 }
 
 func (r SqliteRepository) UpdateEntry(entry SpacedRepetitionEntry) error {
-	_, err := r.db.Exec(SQL_SAVE_ITEM_AUTO_UPDATED, entry.UUID, entry.Body, entry.UserUUID, entry.WhenNext, entry.Body, entry.WhenNext)
+	whenNext := entry.WhenNext.Format(time.RFC3339)
+	_, err := r.db.Exec(SQL_SAVE_ITEM_AUTO_UPDATED, entry.UUID, entry.Body, entry.UserUUID, whenNext, entry.Body, whenNext)
 	if err != nil {
 		return err
 	}

--- a/server/pkg/spaced_repetition/v1.go
+++ b/server/pkg/spaced_repetition/v1.go
@@ -21,7 +21,9 @@ func V1FromPOST(input []byte) ItemInputV1 {
 	item.entry.UUID = hash
 
 	item.entry.Settings.Level = Level_0
-	whenNext := time.Now().Add(time.Hour * 1).UTC()
+	now := time.Now().UTC()
+	whenNext := now.Add(THRESHOLD_0)
+	item.entry.Settings.Created = now.Format(time.RFC3339)
 	item.entry.Settings.WhenNext = whenNext.Format(time.RFC3339)
 	return item
 }
@@ -44,6 +46,11 @@ func (item ItemInputV1) UUID() string {
 
 func (item ItemInputV1) WhenNext() time.Time {
 	t, _ := time.Parse(time.RFC3339, item.entry.Settings.WhenNext)
+	return t
+}
+
+func (item ItemInputV1) Created() time.Time {
+	t, _ := time.Parse(time.RFC3339, item.entry.Settings.Created)
 	return t
 }
 

--- a/server/pkg/spaced_repetition/v2.go
+++ b/server/pkg/spaced_repetition/v2.go
@@ -21,7 +21,9 @@ func V2FromPOST(input []byte) ItemInputV2 {
 	item.entry.UUID = hash
 
 	item.entry.Settings.Level = Level_0
-	whenNext := time.Now().Add(time.Hour * 1).UTC()
+	now := time.Now().UTC()
+	whenNext := now.Add(THRESHOLD_0)
+	item.entry.Settings.Created = now.Format(time.RFC3339)
 	item.entry.Settings.WhenNext = whenNext.Format(time.RFC3339)
 	return item
 }
@@ -45,6 +47,11 @@ func (item ItemInputV2) UUID() string {
 
 func (item ItemInputV2) WhenNext() time.Time {
 	t, _ := time.Parse(time.RFC3339, item.entry.Settings.WhenNext)
+	return t
+}
+
+func (item ItemInputV2) Created() time.Time {
+	t, _ := time.Parse(time.RFC3339, item.entry.Settings.Created)
 	return t
 }
 


### PR DESCRIPTION
# Info
- Adding created timestamp to the table and to the json payloads for spaced repetition entries.
- Doing this, will allow stats to be made around "created" and "updated".


# Todo
- [x] Fix script to update created fields for those that dont have it set.
- [x] Fix here or make a ticket, but the asset build step, needs to trigger openapi-js, to make sure the api is up to date.

Fixes #113 