### PR TITLE
Plugging in kind filtering for challenges

### DIFF
--- a/hugo/layouts/challenge/todo.html
+++ b/hugo/layouts/challenge/todo.html
@@ -1,0 +1,7 @@
+{{ define "meta" }}
+<meta name="robots" content="noindex,nofollow">
+{{ end }}
+
+{{ define "main" }}
+<p>Challenge kind todo is a throw away</p>
+{{ end }}

--- a/openapi/api.challenge.yaml
+++ b/openapi/api.challenge.yaml
@@ -1,5 +1,10 @@
 components:
   schemas:
+    ChallengeKind:
+      type: string
+      default: ""
+      enum:
+        - plank-group
     ChallengePlankRecord:
       type: object
       allOf:
@@ -17,10 +22,11 @@ components:
       properties:
         kind:
           type: string
-          enum:
-            - plank-group
+          description: "Look at ChallengeKind for supported kinds"
+          default: ""
         description:
           type: string
+          default: ""
     ChallengeShortInfo:
       required:
         - uuid
@@ -110,6 +116,11 @@ paths:
             type: string
           required: true
           description: userUUID to get challenges
+        - in: query
+          name: kind
+          description: Filter challenges by a single kind
+          schema:
+            $ref: "#/components/schemas/ChallengeKind"
       responses:
         "200":
           description: Return list of all challenges

--- a/server/db/201910050200-acl-simple.sql
+++ b/server/db/201910050200-acl-simple.sql
@@ -6,3 +6,4 @@ CREATE TABLE IF NOT EXISTS acl_simple (
 );
 
 CREATE INDEX IF NOT EXISTS ext_uuid_lookup ON acl_simple (ext_uuid);
+CREATE INDEX IF NOT EXISTS user_uuid_lookup ON acl_simple (user_uuid);

--- a/server/e2e/smoke_challenge_plank_test.go
+++ b/server/e2e/smoke_challenge_plank_test.go
@@ -116,4 +116,73 @@ var _ = Describe("Smoke Challenge Plank", func() {
 		Expect(err).To(BeNil())
 		Expect(response.StatusCode).To(Equal(http.StatusOK))
 	})
+
+	FIt("Test filtering via kind", func() {
+		// Create user
+		// Login
+		// Create challenge TODO
+		// Create challenge plank-group
+		// Query all
+		// Query TODO
+		// Query plank-group
+		// Delete user
+
+		// Create user
+		ctx := context.Background()
+		input := openapi.HttpUserRegisterInput{
+			Username: generateUsername(),
+			Password: "test123",
+		}
+		data1, response, err := client.UserApi.RegisterUserWithUsernameAndPassword(ctx, input)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusCreated))
+		Expect(data1.Username).To(Equal(input.Username))
+
+		// Login
+		loginInfo, response, err := client.UserApi.LoginWithUsernameAndPassword(ctx, openapi.HttpUserLoginRequest{
+			Username: input.Username,
+			Password: input.Password,
+		})
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		Expect(loginInfo.UserUuid).To(Equal(data1.Uuid))
+		auth := context.WithValue(ctx, openapi.ContextAccessToken, loginInfo.Token)
+
+		// Create challenge TODO
+		challengeInput := openapi.ChallengeInput{
+			Description: "hello",
+			Kind:        challenge.KindTODO,
+		}
+		info, response, err := client.ChallengeApi.CreateChallenge(auth, challengeInput)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusCreated))
+		Expect(info.Kind).To(Equal(challengeInput.Kind))
+		Expect(info.Description).To(Equal(challengeInput.Description))
+
+		// Create challenge plankGroup
+		challengeInput = openapi.ChallengeInput{
+			Description: "hello",
+			Kind:        challenge.KindPlankGroup,
+		}
+		info, response, err = client.ChallengeApi.CreateChallenge(auth, challengeInput)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusCreated))
+		Expect(info.Kind).To(Equal(challengeInput.Kind))
+		Expect(info.Description).To(Equal(challengeInput.Description))
+
+		items, response, err := client.ChallengeApi.GetChallengesByUser(auth, loginInfo.UserUuid, nil)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		Expect(len(items)).To(Equal(2))
+
+		items, response, err = client.ChallengeApi.GetChallengesByUser(auth, loginInfo.UserUuid, &openapi.GetChallengesByUserOpts{Kind: optional.NewInterface(challenge.KindPlankGroup)})
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		Expect(len(items)).To(Equal(1))
+
+		// Delete user
+		_, response, err = client.UserApi.DeleteUser(auth, data1.Uuid)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+	})
 })

--- a/server/e2e/smoke_challenge_plank_test.go
+++ b/server/e2e/smoke_challenge_plank_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Smoke Challenge Plank", func() {
 		Expect(response.StatusCode).To(Equal(http.StatusOK))
 	})
 
-	FIt("Test filtering via kind", func() {
+	It("Test filtering via kind", func() {
 		// Create user
 		// Login
 		// Create challenge TODO

--- a/server/mocks/ChallengeRepository.go
+++ b/server/mocks/ChallengeRepository.go
@@ -110,13 +110,13 @@ func (_m *ChallengeRepository) Get(UUID string) (challenge.ChallengeInfo, error)
 	return r0, r1
 }
 
-// GetChallengesByUser provides a mock function with given fields: userUUID
-func (_m *ChallengeRepository) GetChallengesByUser(userUUID string) ([]challenge.ChallengeShortInfo, error) {
-	ret := _m.Called(userUUID)
+// GetChallengesByUser provides a mock function with given fields: userUUID, filterByKind
+func (_m *ChallengeRepository) GetChallengesByUser(userUUID string, filterByKind string) ([]challenge.ChallengeShortInfo, error) {
+	ret := _m.Called(userUUID, filterByKind)
 
 	var r0 []challenge.ChallengeShortInfo
-	if rf, ok := ret.Get(0).(func(string) []challenge.ChallengeShortInfo); ok {
-		r0 = rf(userUUID)
+	if rf, ok := ret.Get(0).(func(string, string) []challenge.ChallengeShortInfo); ok {
+		r0 = rf(userUUID, filterByKind)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]challenge.ChallengeShortInfo)
@@ -124,8 +124,8 @@ func (_m *ChallengeRepository) GetChallengesByUser(userUUID string) ([]challenge
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userUUID)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(userUUID, filterByKind)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/pkg/challenge/doc.go
+++ b/server/pkg/challenge/doc.go
@@ -79,7 +79,7 @@ type ChallengePushNotificationRepository interface {
 }
 
 type ChallengeRepository interface {
-	GetChallengesByUser(userUUID string) ([]ChallengeShortInfo, error)
+	GetChallengesByUser(userUUID string, filterByKind string) ([]ChallengeShortInfo, error)
 	Join(UUID string, userUUID string) error
 	Leave(UUID string, userUUID string) error
 	Create(userUUID string, challenge ChallengeInfo) error
@@ -118,7 +118,12 @@ var (
 	EventKindPlank            = "plank"
 	EventKindSpacedRepetition = "srs"
 	KindPlankGroup            = "plank-group"
-	PlankGroupMobileApps      = []string{
+	KindTODO                  = "todo" // TODO remove this when I have a new group
+	ChallengeKinds            = []string{
+		KindPlankGroup,
+		KindTODO,
+	}
+	PlankGroupMobileApps = []string{
 		apps.PlankV1,
 	}
 )

--- a/server/pkg/challenge/service.go
+++ b/server/pkg/challenge/service.go
@@ -49,6 +49,14 @@ func (s ChallengeService) Challenges(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, response)
 	}
 
+	allowed := []string{"", KindPlankGroup}
+	if !utils.StringArrayContains(allowed, filterByKind) {
+		response := api.HTTPResponseMessage{
+			Message: "Not valid kind",
+		}
+		return c.JSON(http.StatusUnprocessableEntity, response)
+	}
+
 	challenges, _ := s.repo.GetChallengesByUser(lookupUserUUID, filterByKind)
 	return c.JSON(http.StatusOK, challenges)
 }

--- a/server/pkg/challenge/service.go
+++ b/server/pkg/challenge/service.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/freshteapot/learnalist-api/server/api/i18n"
+	"github.com/freshteapot/learnalist-api/server/api/utils"
 	"github.com/freshteapot/learnalist-api/server/api/uuid"
 	"github.com/freshteapot/learnalist-api/server/pkg/acl"
 	"github.com/freshteapot/learnalist-api/server/pkg/api"
@@ -39,6 +40,7 @@ func (s ChallengeService) Challenges(c echo.Context) error {
 	user := c.Get("loggedInUser").(uuid.User)
 	userUUID := user.Uuid
 	lookupUserUUID := c.Param("userUUID")
+	filterByKind := c.QueryParam("kind")
 
 	if lookupUserUUID != userUUID {
 		response := api.HTTPResponseMessage{
@@ -47,7 +49,7 @@ func (s ChallengeService) Challenges(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, response)
 	}
 
-	challenges, _ := s.repo.GetChallengesByUser(lookupUserUUID)
+	challenges, _ := s.repo.GetChallengesByUser(lookupUserUUID, filterByKind)
 	return c.JSON(http.StatusOK, challenges)
 }
 
@@ -68,7 +70,8 @@ func (s ChallengeService) Create(c echo.Context) error {
 		return c.JSON(http.StatusUnprocessableEntity, response)
 	}
 
-	if challengeInput.Kind != KindPlankGroup {
+	allowed := ChallengeKinds
+	if !utils.StringArrayContains(allowed, challengeInput.Kind) {
 		response := api.HTTPResponseMessage{
 			Message: "Not valid kind",
 		}

--- a/server/pkg/challenge/sqlite_test.go
+++ b/server/pkg/challenge/sqlite_test.go
@@ -1,0 +1,140 @@
+package challenge_test
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/freshteapot/learnalist-api/server/api/label"
+	"github.com/freshteapot/learnalist-api/server/pkg/challenge"
+	helper "github.com/freshteapot/learnalist-api/server/pkg/testhelper"
+
+	"github.com/jmoiron/sqlx"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Testing Sqlite", func() {
+	var (
+		dbCon         *sqlx.DB
+		mockSql       sqlmock.Sqlmock
+		labels        label.LabelReadWriter
+		challengeRepo challenge.ChallengeRepository
+	)
+
+	BeforeEach(func() {
+		dbCon, mockSql, _ = helper.GetMockDB()
+		challengeRepo = challenge.NewSqliteRepository(dbCon)
+	})
+
+	AfterEach(func() {
+		dbCon.Close()
+	})
+
+	It("", func() {
+		fmt.Println(mockSql, labels)
+		Expect("").To(Equal(""))
+	})
+
+	It("", func() {
+		var err error
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	When("Getting challenges for a user", func() {
+		var (
+			kind       = ""
+			userUUID   = "fake-123"
+			preQuery   = fmt.Sprintf(challenge.SqlGetChallengesByUser, userUUID, userUUID)
+			challenge1 challenge.ChallengeShortInfo
+			challenge2 challenge.ChallengeShortInfo
+			created    time.Time
+		)
+
+		BeforeEach(func() {
+			created, _ = time.Parse(time.RFC3339Nano, "2020-12-15T14:30:30Z")
+			challenge1 = challenge.ChallengeShortInfo{
+				UUID:        "fake-challenge-1",
+				Kind:        challenge.KindPlankGroup,
+				Description: "hello",
+				Created:     created.Format(time.RFC3339Nano),
+				CreatedBy:   "fake-user-1",
+			}
+			challenge2 = challenge.ChallengeShortInfo{
+				UUID:        "fake-challenge-2",
+				Kind:        "todo",
+				Description: "hello",
+				Created:     created.Format(time.RFC3339Nano),
+				CreatedBy:   "fake-user-1",
+			}
+		})
+
+		It("When there is an error", func() {
+			want := sql.ErrNoRows
+			query, args, _ := sqlx.In(preQuery, userUUID, challenge.ChallengeKinds)
+			query = dbCon.Rebind(query)
+
+			// TODO if we add new challenge kinds, this will break
+			mockSql.ExpectQuery(query).WithArgs(args[0], args[1], args[2]).
+				WillReturnError(want)
+
+			resp, err := challengeRepo.GetChallengesByUser(userUUID, kind)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(want))
+			Expect(len(resp)).To(Equal(0))
+		})
+
+		It("no results", func() {
+			query, args, _ := sqlx.In(preQuery, userUUID, []string{challenge.KindPlankGroup})
+			query = dbCon.Rebind(query)
+
+			mockSql.ExpectQuery(query).WithArgs(args[0], args[1]).WillReturnError(sql.ErrNoRows)
+
+			resp, err := challengeRepo.GetChallengesByUser(userUUID, challenge.KindPlankGroup)
+			Expect(err).To(Equal(sql.ErrNoRows))
+			Expect(len(resp)).To(Equal(0))
+		})
+
+		It("Find all challenges", func() {
+			rs := sqlmock.NewRows([]string{
+				"uuid",
+				"kind",
+				"description",
+				"created",
+				"user_uuid",
+			}).
+				AddRow(challenge1.UUID, challenge1.Kind, challenge1.Description, created, challenge1.CreatedBy).
+				AddRow(challenge2.UUID, challenge2.Kind, challenge2.Description, created, challenge2.CreatedBy)
+
+			query, args, _ := sqlx.In(preQuery, userUUID, challenge.ChallengeKinds)
+			query = dbCon.Rebind(query)
+			mockSql.ExpectQuery(query).WithArgs(args[0], args[1], args[2]).WillReturnRows(rs)
+
+			resp, err := challengeRepo.GetChallengesByUser(userUUID, "")
+			Expect(err).To(BeNil())
+			Expect(len(resp)).To(Equal(2))
+			Expect(resp[0]).To(Equal(challenge1))
+		})
+
+		It("Find only plank-group", func() {
+			rs := sqlmock.NewRows([]string{
+				"uuid",
+				"kind",
+				"description",
+				"created",
+				"user_uuid",
+			}).
+				AddRow(challenge1.UUID, challenge1.Kind, challenge1.Description, created, challenge1.CreatedBy)
+
+			query, args, _ := sqlx.In(preQuery, userUUID, []string{challenge.KindPlankGroup})
+			query = dbCon.Rebind(query)
+			mockSql.ExpectQuery(query).WithArgs(args[0], args[1]).WillReturnRows(rs)
+
+			resp, err := challengeRepo.GetChallengesByUser(userUUID, challenge.KindPlankGroup)
+			Expect(err).To(BeNil())
+			Expect(len(resp)).To(Equal(1))
+			Expect(resp[0]).To(Equal(challenge1))
+		})
+	})
+})


### PR DESCRIPTION
Goes some way to solving #169.

# What
- Support filtering challenges by kind.

# Todo
- [x] Add index to production for acl_simple
```sh
CREATE INDEX IF NOT EXISTS user_uuid_lookup ON acl_simple (user_uuid);
```