### PR TITLE
Adding header key to restrict user registration via the api

### DIFF
--- a/config/dev.config.yaml
+++ b/config/dev.config.yaml
@@ -24,7 +24,7 @@ server:
     idp:
       issuedTo:
         - "XXX"
-
+  userRegisterKey: ""
 tools:
   integrationTests:
     username: ""

--- a/config/docker.config.yaml
+++ b/config/docker.config.yaml
@@ -21,7 +21,10 @@ server:
       clientID: "XXX"
       clientSecret: "XXX"
       server: "http://localhost:1234"
-
+    idp:
+      issuedTo:
+        - "XXX"
+  userRegisterKey: ""
 tools:
   integrationTests:
     username: ""

--- a/config/lal01.yaml
+++ b/config/lal01.yaml
@@ -21,7 +21,10 @@ server:
       clientID: "XXX"
       clientSecret: "XXX"
       server: "https://learnalist.net"
-
+    idp:
+      issuedTo:
+        - "XXX"
+  userRegisterKey: ""
 tools:
   integrationTests:
     username: ""

--- a/docs/api.user.delete.md
+++ b/docs/api.user.delete.md
@@ -5,7 +5,7 @@
 
 ```sh
 curl -i -XDELETE -H"Authorization: Bearer ${token}" \
-"http://localhost:1234/api/v1/user/${userUUID}"
+"http://127.0.0.1:1234/api/v1/user/${userUUID}"
 ```
 
 ## Response
@@ -30,6 +30,6 @@ response=$(curl -s -XPOST 'http://127.0.0.1:1234/api/v1/user/login' -d'
 ')
 userUUID=$(echo $response | jq -r '.user_uuid')
 token=$(echo $response | jq -r '.token')
-curl -i -XDELETE -H"Authorization: Bearer ${token}" "http://localhost:1234/api/v1/user/${userUUID}"
+curl -i -XDELETE -H"Authorization: Bearer ${token}" "http://127.0.0.1:1234/api/v1/user/${userUUID}"
 ```
 

--- a/docs/api.user.register.md
+++ b/docs/api.user.register.md
@@ -1,5 +1,7 @@
 # Register a user with a username and password
 
+
+
 ## Request
 
 ```sh
@@ -17,4 +19,19 @@ curl -XPOST 'http://127.0.0.1:1234/api/v1/user/register' -d'
   "uuid": "0c6868e3-fc75-5161-be05-ce24ba59226e",
   "username": "iamtest1"
 }
+```
+
+
+## Key lock down of this endpoint
+- Use header "x-user-register"
+- Key is set via server.userRegisterKey in yaml
+- Overridden via env USER_REGISTER_KEY.
+
+```sh
+curl -i -XPOST 'http://127.0.0.1:1234/api/v1/user/register' -H'x-user-register: hello1' -d'
+{
+    "username":"iamtest1",
+    "password":"test123"
+}
+'
 ```

--- a/docs/install-onto-k8s.md
+++ b/docs/install-onto-k8s.md
@@ -293,7 +293,7 @@ nats-server --config /etc/nats-config/nats.conf -sl reload
 ```
 
 
-# Update secrets for learnalist_server
+# Update secret/learnalist-server
 
 ## Create
 ```sh

--- a/docs/install-onto-k8s.md
+++ b/docs/install-onto-k8s.md
@@ -26,7 +26,12 @@ mkdir -p /srv/learnalist/{bin,site-cache}
 cp -rf ./hugo/static/* /srv/learnalist/site-cache/
 cp -r ./hugo /srv/learnalist
 mkdir -p /srv/learnalist/hugo/{public,content/alist,data/alist,content/alistsbyuser,data/alistsbyuser,content/challenge,data/challenge}
-ls server/db/*.sql | sort | xargs cat | sqlite3 /tmp/learnalist/server.db
+ls server/db/*.sql | sort | xargs cat | sqlite3 /srv/learnalist/server.db
+```
+
+# Setup tunnel to kubectl
+```sh
+ssh $SSH_SERVER -L 6443:127.0.0.1:6443 -N &
 ```
 
 # Add resources from k8s
@@ -49,19 +54,11 @@ helm template certs   --name certs   --values values.yaml   --output-dir=./outpu
 
 # Fire up the registry
 - make sure container-registry (docker-registry) is running
-- log onto the server and port-forward 5000
-
-```sh
-ssh $SSH_SERVER sudo kubectl port-forward deployment/container-registry 5000:5000 &
-```
-
-```sh
-ssh $SSH_SERVER -L 6443:127.0.0.1:6443 -N &
-```
+- Setup tunnel to the registry
 
 # Setup tunnel to the registry
 ```sh
-ssh $SSH_SERVER -L 5000:127.0.0.1:5000 -N &
+kubectl port-forward deployment/container-registry 5000:5000 &
 ```
 
 # Push new image
@@ -155,7 +152,6 @@ kubectl config use-context default
 kill -9 $(lsof -ti tcp:6443)
 kill -9 $(lsof -ti tcp:5000)
 ssh $SSH_SERVER -L 6443:127.0.0.1:6443 -N &
-ssh $SSH_SERVER -L 5000:127.0.0.1:5000 -N &
 ```
 
 ```sh
@@ -166,7 +162,7 @@ kill -9 $(lsof -ti tcp:5000)
 
 ```sh
 kubectl scale deployment/container-registry  --replicas=1
-ssh $SSH_SERVER sudo kubectl port-forward deployment/container-registry 5000:5000 &
+kubectl port-forward deployment/container-registry 5000:5000 &
 ```
 
 Push latest image and sync site-assets (js, css)

--- a/docs/install-onto-k8s.md
+++ b/docs/install-onto-k8s.md
@@ -291,3 +291,20 @@ kubectl create configmap nats-config --from-file=nats.conf=./k8s/nats-nats.conf 
 ```sh
 nats-server --config /etc/nats-config/nats.conf -sl reload
 ```
+
+
+# Update secrets for learnalist_server
+
+## Create
+```sh
+kubectl create secret generic learnalist-server \
+  --from-literal=userRegisterKey="XXX"
+```
+
+## Update
+```sh
+kubectl create secret generic learnalist-server \
+--from-literal=userRegisterKey="XXX" \
+--dry-run -o yaml |
+kubectl apply -f -
+```

--- a/k8s/learnalist.yaml
+++ b/k8s/learnalist.yaml
@@ -35,6 +35,11 @@ spec:
               value: "nats.default.svc.cluster.local"
             - name: EVENTS_STAN_CLIENT_ID
               value: "lal-02"
+            - name: USER_REGISTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: userRegisterKey
+                  key: learnalist-sever
 
           volumeMounts:
             - name: config-volume

--- a/k8s/learnalist.yaml
+++ b/k8s/learnalist.yaml
@@ -38,8 +38,8 @@ spec:
             - name: USER_REGISTER_KEY
               valueFrom:
                 secretKeyRef:
-                  name: userRegisterKey
-                  key: learnalist-sever
+                  name: learnalist-server
+                  key: userRegisterKey
 
           volumeMounts:
             - name: config-volume

--- a/openapi/api.user.yaml
+++ b/openapi/api.user.yaml
@@ -74,6 +74,12 @@ paths:
         - user
       operationId: registerUserWithUsernameAndPassword
       description: Register a new user with username and password
+      parameters:
+        - in: header
+          name: x-user-register
+          description: Restrict access to this endpoint, if you add the header and it matches the key, you are in.
+          schema:
+            type: string
       requestBody:
         description: Username and password
         required: true

--- a/server/api/api/api.go
+++ b/server/api/api/api.go
@@ -13,14 +13,15 @@ import (
 // m exposing the data abstraction layer
 
 type Manager struct {
-	Datastore      models.Datastore
-	UserManagement user.Management
-	Acl            acl.Acl
-	DatabaseName   string
-	HugoHelper     hugo.HugoSiteBuilder
-	OauthHandlers  oauth.Handlers
-	logger         logrus.FieldLogger
-	insights       event.Insights
+	Datastore       models.Datastore
+	UserManagement  user.Management
+	Acl             acl.Acl
+	DatabaseName    string
+	HugoHelper      hugo.HugoSiteBuilder
+	OauthHandlers   oauth.Handlers
+	logger          logrus.FieldLogger
+	insights        event.Insights
+	UserRegisterKey string
 }
 
 func NewManager(
@@ -30,17 +31,19 @@ func NewManager(
 	databaseName string,
 	hugoHelper hugo.HugoSiteBuilder,
 	oauthHandlers oauth.Handlers,
+	userRegisterKey string,
 	logger logrus.FieldLogger,
 ) *Manager {
 	return &Manager{
-		Datastore:      datastore,
-		UserManagement: userManagement,
-		Acl:            acl,
-		DatabaseName:   databaseName,
-		HugoHelper:     hugoHelper,
-		OauthHandlers:  oauthHandlers,
-		logger:         logger,
-		insights:       event.NewInsights(logger),
+		Datastore:       datastore,
+		UserManagement:  userManagement,
+		Acl:             acl,
+		DatabaseName:    databaseName,
+		HugoHelper:      hugoHelper,
+		OauthHandlers:   oauthHandlers,
+		logger:          logger,
+		insights:        event.NewInsights(logger),
+		UserRegisterKey: userRegisterKey,
 	}
 }
 

--- a/server/api/api/oauth_google_callback_test.go
+++ b/server/api/api/oauth_google_callback_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Testing Google Oauth callback", func() {
 		datastore.On("UserFromIDP").Return(userFromIDP)
 		datastore.On("OAuthHandler").Return(oauthReadWriter)
 
-		manager = api.NewManager(datastore, userManagement, acl, "", testHugoHelper, oauthHandlers, logger)
+		manager = api.NewManager(datastore, userManagement, acl, "", testHugoHelper, oauthHandlers, "", logger)
 
 		method = http.MethodGet
 		uriPrefix = "/api/v1/oauth/google/callback"

--- a/server/api/api/user_delete_test.go
+++ b/server/api/api/user_delete_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Testing user delete endpoint", func() {
 		oauthHandlers := oauth.Handlers{}
 		hugoHelper = &mocks.HugoSiteBuilder{}
 
-		manager = api.NewManager(datastore, userManagement, acl, "", hugoHelper, oauthHandlers, logger)
+		manager = api.NewManager(datastore, userManagement, acl, "", hugoHelper, oauthHandlers, "", logger)
 
 		userUUID = "fake-123"
 		session.Token = "fake-token"

--- a/server/api/api/user_register.go
+++ b/server/api/api/user_register.go
@@ -18,6 +18,16 @@ import (
 // When a user is created with the same username and password it returns a 200.
 // When a user is created with a username in the system it returns a 400.
 func (m *Manager) V1PostRegister(c echo.Context) error {
+
+	if m.UserRegisterKey != "" {
+		registerKey := c.Request().Header.Get("x-user-register")
+		if registerKey != m.UserRegisterKey {
+			return c.JSON(http.StatusForbidden, api.HTTPResponseMessage{
+				Message: "User registration is locked down and requires key to add users",
+			})
+		}
+	}
+
 	var input api.HTTPUserRegisterInput
 	defer c.Request().Body.Close()
 	jsonBytes, _ := ioutil.ReadAll(c.Request().Body)

--- a/server/cmd/server/server.go
+++ b/server/cmd/server/server.go
@@ -44,8 +44,8 @@ var ServerCmd = &cobra.Command{
 		logger := logging.GetLogger()
 		event.SetDefaultSettingsForCMD()
 
-		viper.SetDefault("server.user-register-key", "")
-		viper.BindEnv("server.user-register-key", "USER_REGISTER_KEY")
+		viper.SetDefault("server.userRegisterKey", "")
+		viper.BindEnv("server.userRegisterKey", "USER_REGISTER_KEY")
 
 		googleOauthConfig := oauth.NewGoogle(oauth.GoogleConfig{
 			Key:    viper.GetString("server.loginWith.google.clientID"),
@@ -58,7 +58,7 @@ var ServerCmd = &cobra.Command{
 			Google: googleOauthConfig,
 		}
 
-		userRegisterKey := viper.GetString("server.user-register-key")
+		userRegisterKey := viper.GetString("server.userRegisterKey")
 		databaseName := viper.GetString("server.sqlite.database")
 		port := viper.GetString("server.port")
 		corsAllowedOrigins := viper.GetString("server.cors.allowedOrigins")

--- a/server/cmd/server/server.go
+++ b/server/cmd/server/server.go
@@ -44,6 +44,9 @@ var ServerCmd = &cobra.Command{
 		logger := logging.GetLogger()
 		event.SetDefaultSettingsForCMD()
 
+		viper.SetDefault("server.user-register-key", "")
+		viper.BindEnv("server.user-register-key", "USER_REGISTER_KEY")
+
 		googleOauthConfig := oauth.NewGoogle(oauth.GoogleConfig{
 			Key:    viper.GetString("server.loginWith.google.clientID"),
 			Secret: viper.GetString("server.loginWith.google.clientSecret"),
@@ -55,6 +58,7 @@ var ServerCmd = &cobra.Command{
 			Google: googleOauthConfig,
 		}
 
+		userRegisterKey := viper.GetString("server.user-register-key")
 		databaseName := viper.GetString("server.sqlite.database")
 		port := viper.GetString("server.port")
 		corsAllowedOrigins := viper.GetString("server.cors.allowedOrigins")
@@ -124,7 +128,15 @@ var ServerCmd = &cobra.Command{
 			event.NewInsights(logger),
 		)
 
-		apiManager := api.NewManager(dal, userManagement, acl, "", hugoHelper, *oauthHandlers, logger)
+		apiManager := api.NewManager(
+			dal,
+			userManagement,
+			acl,
+			"",
+			hugoHelper,
+			*oauthHandlers,
+			userRegisterKey,
+			logger)
 
 		// TODO how to hook up sse https://gist.github.com/freshteapot/d467adb7cb082d2d056205deb38a9694
 		spacedRepetitionService := spaced_repetition.NewService(db)


### PR DESCRIPTION
Resolves #153

# Todo
- [x] Add key to production

# How
## Without setting the key
```sh
make clear-site rebuild-db
EVENTS_VIA="nats" \
EVENTS_STAN_CLUSTER_ID="test-cluster" \
EVENTS_STAN_CLIENT_ID="lal-server" \
EVENTS_NATS_SERVER="127.0.0.1" \
HUGO_EXTERNAL=false \
make run-api-server
```

```sh
curl -XPOST 'http://127.0.0.1:1234/api/v1/user/register' -d'
{
    "username":"iamtest1",
    "password":"test123"
}
'
```

## With setting the key
```sh
make clear-site rebuild-db
EVENTS_VIA="nats" \
EVENTS_STAN_CLUSTER_ID="test-cluster" \
EVENTS_STAN_CLIENT_ID="lal-server" \
EVENTS_NATS_SERVER="127.0.0.1" \
HUGO_EXTERNAL=false \
USER_REGISTER_KEY="hello" \
make run-api-server
```

```sh
curl -i -XPOST 'http://127.0.0.1:1234/api/v1/user/register' -H'x-user-register: hello' -d'
{
    "username":"iamtest1",
    "password":"test123"
}
'
```