### PR TITLE
Handling when entry has reached the highest spaced learning level

### DIFF
--- a/server/pkg/spaced_repetition/doc.go
+++ b/server/pkg/spaced_repetition/doc.go
@@ -133,6 +133,11 @@ var incrThresholds = []struct {
 		Level:     Level9,
 		Threshold: Threshold9,
 	},
+	{
+		Match:     Level9,
+		Level:     Level9,
+		Threshold: Threshold9,
+	},
 }
 
 var decrThresholds = []struct {


### PR DESCRIPTION
# What
- When entry reaches level9, now we match against it, instead of falling thru.

Fixes #218 