### PR TITLE
Remove the prompt before leaving the page

### DIFF
--- a/js/src/plank/stats/v1.svelte
+++ b/js/src/plank/stats/v1.svelte
@@ -22,7 +22,6 @@
 
   function beforeunload(event) {
     clearNotification();
-    return (event.returnValue = "");
   }
 
   $: checkLogin();


### PR DESCRIPTION
By mistake I added a prompt when trying to leave the plank-stats-v1.html page.
It should just leave :)