### PR TITLE
Gh 230

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ rebuild-db-remind-manager:
 rebuild-static-site:
 	cd server && \
 	EVENTS_STAN_CLIENT_ID=rebuild-static-site \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run --tags="json1" main.go tools rebuild-static-site --config=../config/dev.config.yaml
 
 test:
@@ -63,8 +61,6 @@ run-challenges-sync:
 	cd server && \
 	TOPIC=lal.monolog \
 	EVENTS_STAN_CLIENT_ID=challenges-sync \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run main.go --config=../config/dev.config.yaml \
 	tools challenges sync
 
@@ -72,40 +68,36 @@ run-notifications-push-notifications:
 	cd server && \
 	TOPIC=notifications \
 	EVENTS_STAN_CLIENT_ID=notifications-push-notifications \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run main.go --config=../config/dev.config.yaml \
 	tools notifications push-notifications
 
 run-api-server:
 	cd server && \
 	EVENTS_STAN_CLIENT_ID=lal-server \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run --tags="json1" main.go --config=../config/dev.config.yaml server
 
 run-remind-manager:
 	cd server && \
 	TOPIC=lal.monolog \
 	EVENTS_STAN_CLIENT_ID=remind-daily \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run --tags=json1 main.go --config=../config/dev.config.yaml \
 	tools remind manager
 
 run-static-site:
 	cd server && \
 	EVENTS_STAN_CLIENT_ID=static-site \
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
 	go run main.go --config=../config/dev.config.yaml \
 	static-site
+
+run-event-reader:
+	cd server && \
+	EVENTS_STAN_CLIENT_ID="lal-event-reader" \
+	go run main.go --config=../config/dev.config.yaml tools event-reader
 
 # Running development with hugo and golang ran outside of the javascript landscape
 # Enables the ability to expose the code to my ip address not just localhost
 develop:
-	EVENTS_STAN_CLUSTER_ID=test-cluster \
-	EVENTS_NATS_SERVER=127.0.0.1 \
+	EVENTS_STAN_CLIENT_ID=lal-server \
 	scripts/run-hugo.sh
 
 develop-localhost:

--- a/config/dev.config.yaml
+++ b/config/dev.config.yaml
@@ -12,6 +12,12 @@ remind:
 server:
   assets:
     directory: "/tmp/learnalist/assets"
+  events:
+    nats:
+      server: 127.0.0.1
+    stan:
+      clusterID: test-cluster
+
   sqlite:
     database: /tmp/learnalist/server.db
   fcm:

--- a/docs/development/gh-214.md
+++ b/docs/development/gh-214.md
@@ -7,29 +7,17 @@
 
 ## Current
 ```sh
-TOPIC=lal.monolog \
-EVENTS_STAN_CLIENT_ID=tools-alist \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools list public-access f7384934-a621-4126-95f8-335acc6a8fac --current
 ```
 ## Grant
 ```sh
-TOPIC=lal.monolog \
-EVENTS_STAN_CLIENT_ID=tools-alist \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools list public-access f7384934-a621-4126-95f8-335acc6a8fac --access=grant
 ```
 
 ## Revoke
 ```sh
-TOPIC=lal.monolog \
-EVENTS_STAN_CLIENT_ID=tools-alist \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools list public-access f7384934-a621-4126-95f8-335acc6a8fac --access=revoke
 ```

--- a/docs/end-to-end-testing.md
+++ b/docs/end-to-end-testing.md
@@ -1,7 +1,18 @@
 # End to end testing
+
+# Bring online
 ## Get the server up and running
 
-[Setup the server for development](./install-server-for-dev.md)
+```sh
+STATIC_SITE_EXTERNAL=false \
+make clear-site rebuild-db develop
+```
+
+## Start reminder
+
+```sh
+make rebuild-db-remind-manager run-remind-manager
+```
 
 # Run all tests
 ```sh

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -123,13 +123,11 @@ WHERE
 # User tools
 ## Find user
 ```sh
-EVENTS_STAN_CLIENT_ID="tools-user-mangement" \
 /app/bin/learnalist-cli --config=/etc/learnalist/config.yaml tools user find "iamtest1"
 ```
 
 ## Delete user
 ```sh
-EVENTS_STAN_CLIENT_ID="tools-user-mangement" \
 /app/bin/learnalist-cli --config=/etc/learnalist/config.yaml tools user delete
 ```
 

--- a/docs/setup-server-for-development.md
+++ b/docs/setup-server-for-development.md
@@ -36,9 +36,6 @@ Go [try some curl requests.](./play.along.md)
 
 ```sh
 make clear-site rebuild-db
-EVENTS_STAN_CLUSTER_ID="test-cluster" \
-EVENTS_STAN_CLIENT_ID="lal-server" \
-EVENTS_NATS_SERVER="127.0.0.1" \
 make run-api-server
 ```
 
@@ -100,9 +97,6 @@ make run-api-server
 ### nats
 ```sh
 make clear-site rebuild-db
-EVENTS_STAN_CLUSTER_ID="test-cluster" \
-EVENTS_STAN_CLIENT_ID="lal-server" \
-EVENTS_NATS_SERVER="127.0.0.1" \
 make develop
 ```
 ## Running slack events
@@ -118,11 +112,7 @@ scripts/run-slack.sh
 ## Running the event reader
 
 ```sh
-cd server
-EVENTS_STAN_CLUSTER_ID="test-cluster" \
-EVENTS_STAN_CLIENT_ID="lal-event-reader" \
-EVENTS_NATS_SERVER="127.0.0.1" \
-go run main.go --config=../config/dev.config.yaml tools event-reader
+make run-event-reader
 ```
 
 
@@ -130,8 +120,6 @@ go run main.go --config=../config/dev.config.yaml tools event-reader
 ```sh
 TOPIC=lal.monolog \
 EVENTS_STAN_CLIENT_ID=challenges-sync \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools challenge sync
 ```
@@ -145,8 +133,6 @@ Topic where communications goto
 ```sh
 TOPIC=lal.monolog \
 EVENTS_STAN_CLIENT_ID=nats-reader \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools natsutils read
 ```

--- a/server/cmd/server/server.go
+++ b/server/cmd/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/freshteapot/learnalist-api/server/api/database"
 	labelStorage "github.com/freshteapot/learnalist-api/server/api/label/sqlite"
 	"github.com/freshteapot/learnalist-api/server/api/models"
+	"github.com/freshteapot/learnalist-api/server/pkg/acl"
 	aclStorage "github.com/freshteapot/learnalist-api/server/pkg/acl/sqlite"
 	"github.com/freshteapot/learnalist-api/server/pkg/app_settings"
 	"github.com/freshteapot/learnalist-api/server/pkg/assets"
@@ -237,7 +238,10 @@ var ServerCmd = &cobra.Command{
 			logger.WithField("context", "dripfeed-service"),
 		)
 
-		// TODO add acl here
+		_ = acl.NewService(
+			aclRepo,
+			logger.WithField("context", "acl-service"),
+		)
 
 		server.InitApi(
 			apiManager,

--- a/server/cmd/server/server.go
+++ b/server/cmd/server/server.go
@@ -237,6 +237,8 @@ var ServerCmd = &cobra.Command{
 			logger.WithField("context", "dripfeed-service"),
 		)
 
+		// TODO add acl here
+
 		server.InitApi(
 			apiManager,
 			userSession,

--- a/server/cmd/server/static-site.go
+++ b/server/cmd/server/static-site.go
@@ -31,7 +31,6 @@ static-site
 		logContext := logger.WithField("context", "static-site")
 
 		event.SetDefaultSettingsForCMD()
-		viper.SetDefault("topic", event.TopicStaticSite)
 		event.SetupEventBus(logContext)
 
 		viper.SetDefault("topic", event.TopicStaticSite)

--- a/server/cmd/server/static-site.go
+++ b/server/cmd/server/static-site.go
@@ -21,8 +21,6 @@ var StaticSiteCMD = &cobra.Command{
 	Short: "Run the static-site",
 	Long: `
 EVENTS_STAN_CLIENT_ID=static-site \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 static-site
 `,

--- a/server/cmd/tools/alist/publicaccess.go
+++ b/server/cmd/tools/alist/publicaccess.go
@@ -24,10 +24,6 @@ var publicAccessCMD = &cobra.Command{
 	Long: `
 Example:
 
-TOPIC=lal.monolog \
-EVENTS_STAN_CLIENT_ID=tools-alist \
-EVENTS_STAN_CLUSTER_ID=test-cluster \
-EVENTS_NATS_SERVER=127.0.0.1 \
 go run main.go --config=../config/dev.config.yaml \
 tools list public-access chris --access=revoke
 `,

--- a/server/cmd/tools/challenges/sync.go
+++ b/server/cmd/tools/challenges/sync.go
@@ -35,7 +35,7 @@ var syncCMD = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logging.GetLogger()
 		event.SetDefaultSettingsForCMD()
-		viper.SetDefault("topic", "lal.monolog")
+		viper.SetDefault("topic", event.TopicMonolog)
 		viper.BindEnv("topic", "TOPIC")
 		subjectRead := viper.GetString("topic")
 		subjectWrite := "challenges"

--- a/server/cmd/tools/natsutils/read.go
+++ b/server/cmd/tools/natsutils/read.go
@@ -38,7 +38,7 @@ var readCMD = &cobra.Command{
 		logger := logging.GetLogger()
 		logger.Info("Read events")
 		event.SetDefaultSettingsForCMD()
-		viper.SetDefault("topic", "lal.monolog")
+		viper.SetDefault("topic", event.TopicMonolog)
 		viper.BindEnv("topic", "TOPIC")
 
 		topic := viper.GetString("topic")

--- a/server/cmd/tools/natsutils/write.go
+++ b/server/cmd/tools/natsutils/write.go
@@ -32,7 +32,7 @@ var writeCMD = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logging.GetLogger()
 		event.SetDefaultSettingsForCMD()
-		viper.SetDefault("topic", "lal.monolog")
+		viper.SetDefault("topic", event.TopicMonolog)
 		viper.BindEnv("topic", "TOPIC")
 
 		topic := viper.GetString("topic")

--- a/server/cmd/tools/user/delete.go
+++ b/server/cmd/tools/user/delete.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/freshteapot/learnalist-api/server/api/database"
 	"github.com/freshteapot/learnalist-api/server/pkg/event"
@@ -21,6 +22,7 @@ var deleteUserCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logging.GetLogger()
 		event.SetDefaultSettingsForCMD()
+		os.Setenv("EVENTS_STAN_CLIENT_ID", "tools-user-mangement")
 		event.SetupEventBus(logger.WithField("context", "tools-user-delete"))
 
 		dsn := viper.GetString("server.sqlite.database")

--- a/server/pkg/acl/acl_suite_test.go
+++ b/server/pkg/acl/acl_suite_test.go
@@ -1,0 +1,13 @@
+package acl_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuthenticate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Acl Test Suite")
+}

--- a/server/pkg/acl/events.go
+++ b/server/pkg/acl/events.go
@@ -28,7 +28,7 @@ func (s AclService) handlePublicListAccess(entry event.Eventlog) {
 	if err != nil {
 		return
 	}
-
+	// Today, this assumes the userUUID exists
 	message := ""
 	switch moment.Action {
 	case "revoke":

--- a/server/pkg/acl/events.go
+++ b/server/pkg/acl/events.go
@@ -46,7 +46,10 @@ func (s AclService) handlePublicListAccess(entry event.Eventlog) {
 	})
 
 	if err != nil {
-		logContext.Fatal("Issue talking to storage")
+		logContext.WithFields(logrus.Fields{
+			"eventHandler": "handlePublicListAccess",
+			"error":        err,
+		}).Fatal("Issue talking to storage")
 	}
 
 	logContext.Info(message)
@@ -58,15 +61,20 @@ func (s AclService) handleApiUserRegister(entry event.Eventlog) {
 		pref   user.UserPreference
 	)
 	b, _ := json.Marshal(entry.Data)
-	json.Unmarshal(b, &moment)
+	err := json.Unmarshal(b, &moment)
+	if err != nil {
+		return
+	}
 
 	userUUID := moment.UUID
 	b, _ = json.Marshal(moment.Data)
-	json.Unmarshal(b, &pref)
+	err = json.Unmarshal(b, &pref)
+	if err != nil {
+		return
+	}
 
 	if pref.Acl.PublicListWrite == 1 {
 		// TODO can I rely on this pref.UserUUID?
-
 		err := s.repo.GrantUserPublicListWriteAccess(userUUID)
 		if err != nil {
 			s.logContext.WithFields(logrus.Fields{

--- a/server/pkg/acl/events_test.go
+++ b/server/pkg/acl/events_test.go
@@ -1,0 +1,135 @@
+package acl_test
+
+import (
+	"errors"
+
+	"github.com/freshteapot/learnalist-api/server/mocks"
+	"github.com/freshteapot/learnalist-api/server/pkg/acl"
+	aclKeys "github.com/freshteapot/learnalist-api/server/pkg/acl/keys"
+	"github.com/freshteapot/learnalist-api/server/pkg/event"
+	"github.com/freshteapot/learnalist-api/server/pkg/testutils"
+	"github.com/freshteapot/learnalist-api/server/pkg/user"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ = Describe("Testing Events", func() {
+	var (
+		eventMessageBus *mocks.EventlogPubSub
+		logger          *logrus.Logger
+		hook            *test.Hook
+
+		want    error
+		service acl.AclService
+		aclRepo *mocks.Acl
+
+		userUUID string
+		moment   event.Eventlog
+	)
+
+	BeforeEach(func() {
+		logger, hook = test.NewNullLogger()
+
+		eventMessageBus = &mocks.EventlogPubSub{}
+		event.SetBus(eventMessageBus)
+		eventMessageBus.On("Subscribe", event.TopicMonolog, "aclService", mock.Anything)
+
+		aclRepo = &mocks.Acl{}
+
+		want = errors.New("want")
+		userUUID = "fake-user-123"
+	})
+
+	When("New user registered", func() {
+		BeforeEach(func() {
+			moment = event.Eventlog{
+				Kind: event.ApiUserRegister,
+				Data: event.EventNewUser{
+					UUID: userUUID,
+					Kind: event.KindUserRegisterUsername,
+					Data: user.UserPreference{
+						Acl: user.ACL{
+							PublicListWrite: 1,
+						},
+					},
+				},
+			}
+		})
+
+		It("Issue saving", func() {
+			testutils.SetLoggerToPanicOnFatal(logger)
+			aclRepo.On("GrantUserPublicListWriteAccess", userUUID).Return(want)
+			service = acl.NewService(aclRepo, logger)
+			Expect(func() { service.OnEvent(moment) }).Should(Panic())
+			Expect(hook.LastEntry().Data["error"]).To(Equal(want))
+		})
+
+		It("Success", func() {
+			aclRepo.On("GrantUserPublicListWriteAccess", userUUID).Return(nil)
+			service = acl.NewService(aclRepo, logger)
+			service.OnEvent(moment)
+			Expect(hook.LastEntry()).To(BeNil())
+		})
+	})
+
+	When("Changing users right to create public lists", func() {
+		When("Granting", func() {
+			BeforeEach(func() {
+				moment = event.Eventlog{
+					Kind: acl.EventPublicListAccess,
+					Data: acl.EventPublicListAccessData{
+						UserUUID: userUUID,
+						Action:   aclKeys.ActionGrant,
+					},
+					TriggeredBy: "cmd",
+				}
+			})
+
+			It("Issue saving", func() {
+				testutils.SetLoggerToPanicOnFatal(logger)
+				aclRepo.On("GrantUserPublicListWriteAccess", userUUID).Return(want)
+				service = acl.NewService(aclRepo, logger)
+				Expect(func() { service.OnEvent(moment) }).Should(Panic())
+				Expect(hook.LastEntry().Data["error"]).To(Equal(want))
+			})
+
+			It("Success", func() {
+				aclRepo.On("GrantUserPublicListWriteAccess", userUUID).Return(nil)
+				service = acl.NewService(aclRepo, logger)
+				service.OnEvent(moment)
+				Expect(hook.LastEntry().Message).To(Equal("Access granted"))
+			})
+		})
+
+		When("Revoking", func() {
+			BeforeEach(func() {
+				moment = event.Eventlog{
+					Kind: acl.EventPublicListAccess,
+					Data: acl.EventPublicListAccessData{
+						UserUUID: userUUID,
+						Action:   aclKeys.ActionRevoke,
+					},
+					TriggeredBy: "cmd",
+				}
+			})
+
+			It("Issue saving", func() {
+				testutils.SetLoggerToPanicOnFatal(logger)
+				aclRepo.On("RevokeUserPublicListWriteAccess", userUUID).Return(want)
+				service = acl.NewService(aclRepo, logger)
+				Expect(func() { service.OnEvent(moment) }).Should(Panic())
+				Expect(hook.LastEntry().Data["error"]).To(Equal(want))
+			})
+
+			It("Success", func() {
+				aclRepo.On("RevokeUserPublicListWriteAccess", userUUID).Return(nil)
+				service = acl.NewService(aclRepo, logger)
+				service.OnEvent(moment)
+				Expect(hook.LastEntry().Message).To(Equal("Access revoked"))
+			})
+		})
+	})
+})

--- a/server/pkg/acl/service.go
+++ b/server/pkg/acl/service.go
@@ -16,6 +16,6 @@ func NewService(repo Acl, log logrus.FieldLogger) AclService {
 		logContext: log,
 	}
 
-	event.GetBus().Subscribe(event.TopicMonolog, "acl", s.OnEvent)
+	event.GetBus().Subscribe(event.TopicMonolog, "aclService", s.OnEvent)
 	return s
 }

--- a/server/pkg/event/slack/slack_v1.go
+++ b/server/pkg/event/slack/slack_v1.go
@@ -271,7 +271,7 @@ func (s SlackEvents) Read(entry event.Eventlog) {
 		switch moment.Action {
 		case aclKeys.ActionGrant:
 			msg.Text = fmt.Sprintf("user:%s is allowed to create public lists", moment.UserUUID)
-		case event.ActionDeleted:
+		case aclKeys.ActionRevoke:
 			msg.Text = fmt.Sprintf("user:%s is no longer allowed to create public lists", moment.UserUUID)
 		default:
 			msg.Text = fmt.Sprintf(`%s action not supported %s`, moment.Action, entry.Kind)

--- a/server/pkg/event/slack/slack_v1.go
+++ b/server/pkg/event/slack/slack_v1.go
@@ -250,10 +250,6 @@ func (s SlackEvents) Read(entry event.Eventlog) {
 			msg.Text = fmt.Sprintf(`%s action not supported %s`, entry.Kind, entry.Action)
 		}
 	case event.ApiAppSettingsRemindV1:
-		//b, _ := json.Marshal(entry.Data)
-		//var settings openapi.AppSettingsRemindV1
-		//json.Unmarshal(b, &settings)
-
 		userUUID := entry.UUID
 		switch entry.Action {
 		case event.ActionUpsert:

--- a/server/pkg/event/slack/slack_v1.go
+++ b/server/pkg/event/slack/slack_v1.go
@@ -90,7 +90,6 @@ func (s SlackEvents) Read(entry event.Eventlog) {
 		b, _ := json.Marshal(entry.Data)
 		var moment event.EventList
 		json.Unmarshal(b, &moment)
-		// TODO https://github.com/freshteapot/learnalist-api/issues/212
 		msg.Text = fmt.Sprintf("list:%s deleted by user:%s", moment.UUID, moment.UserUUID)
 	case event.ApiSpacedRepetition:
 		b, _ := json.Marshal(entry.Data)

--- a/server/pkg/event/slack/v1_test.go
+++ b/server/pkg/event/slack/v1_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/freshteapot/learnalist-api/server/api/alist"
+	"github.com/freshteapot/learnalist-api/server/pkg/acl"
 	"github.com/freshteapot/learnalist-api/server/pkg/acl/keys"
 	"github.com/freshteapot/learnalist-api/server/pkg/apps"
 	"github.com/freshteapot/learnalist-api/server/pkg/challenge"
@@ -459,6 +460,53 @@ var _ = Describe("Testing Events to Slack", func() {
 				},
 			},
 			// finish:spaced-repetition.overtime
+			// start: acl.access
+			{
+				entry: event.Eventlog{
+					Kind: acl.EventPublicListAccess,
+					Data: acl.EventPublicListAccessData{
+						UserUUID: userUUID,
+						Action:   "grant",
+					},
+					TriggeredBy: "cmd",
+				},
+				post: func(url string, msg *slack.WebhookMessage) error {
+					expect := `user:fake-user-123 is allowed to create public lists`
+					Expect(msg.Text).To(Equal(expect))
+					return nil
+				},
+			},
+			{
+				entry: event.Eventlog{
+					Kind: acl.EventPublicListAccess,
+					Data: acl.EventPublicListAccessData{
+						UserUUID: userUUID,
+						Action:   "revoke",
+					},
+					TriggeredBy: "cmd",
+				},
+				post: func(url string, msg *slack.WebhookMessage) error {
+					expect := `user:fake-user-123 is no longer allowed to create public lists`
+					Expect(msg.Text).To(Equal(expect))
+					return nil
+				},
+			},
+			{
+				entry: event.Eventlog{
+					Kind: acl.EventPublicListAccess,
+					Data: acl.EventPublicListAccessData{
+						UserUUID: userUUID,
+						Action:   "a1",
+					},
+					TriggeredBy: "cmd",
+				},
+				post: func(url string, msg *slack.WebhookMessage) error {
+					expect := `a1 action not supported acl.publicListAccess`
+					Expect(msg.Text).To(Equal(expect))
+					return nil
+				},
+			},
+			// finish: acl.access
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
# What
- Fix Granting or revoking users ability to create public lists via the command line (#230)
- Using event.TopicMonolog everywhere
- Improving the documentation around running e2e tests

# Todo
- [x] Confirm it works via command line
- [x] Confirm slack shows a nice message
- [x] Add tests
- [x] Do I want a command to set users public lists to private?

Fixes #230 

# How to test
## Register user
```sh
curl -XPOST 'http://127.0.0.1:1234/api/v1/user/register' -d'
{
    "username":"iamtest1",
    "password":"test123"
}
'
```
## Trigger

```
cd server
go run main.go --config=../config/dev.config.yaml \
tools list public-access b78ecba5-e1f1-47a8-8c0e-acd89098f18f --access=grant
```