### PR TITLE
Adding support pages for the mobile apps

### DIFF
--- a/hugo/content/faq/support-mobile-humble-plank-v1.md
+++ b/hugo/content/faq/support-mobile-humble-plank-v1.md
@@ -1,0 +1,14 @@
+---
+title: Humble Plank Support
+js_include: []
+css_include: ["main"]
+---
+
+# What is the Humble Plank mobile app
+[Overview of why you might want to download the humble plank](../features/mobile-humble-plank-v1.md)
+
+# Something wrong?
+Please [report your problem](https://github.com/learnalist/support/issues/new).
+
+# Want to request a feature?
+Please [describe your feature](https://github.com/learnalist/support/issues/new).

--- a/hugo/content/faq/support-mobile-humble-plank-v1.md
+++ b/hugo/content/faq/support-mobile-humble-plank-v1.md
@@ -5,8 +5,7 @@ css_include: ["main"]
 ---
 
 # What is the Humble Plank mobile app
-[Overview of why you might want to download the humble plank](../features/mobile-humble-plank-v1.md)
-
+[Overview of why you might want to download the humble plank]({{< ref "/features/mobile-humble-plank-v1.md" >}})
 # Something wrong?
 Please [report your problem](https://github.com/learnalist/support/issues/new).
 

--- a/hugo/content/faq/support-mobile-remind-v1.md
+++ b/hugo/content/faq/support-mobile-remind-v1.md
@@ -1,0 +1,14 @@
+---
+title: Remind Support
+js_include: []
+css_include: ["main"]
+---
+
+# What is the Remind mobile app
+[Overview of why you might want to download remind](../features/mobile-remind-v1.md)
+
+# Something wrong?
+Please [report your problem](https://github.com/learnalist/support/issues/new).
+
+# Want to request a feature?
+Please [describe your feature](https://github.com/learnalist/support/issues/new).

--- a/hugo/content/faq/support-mobile-remind-v1.md
+++ b/hugo/content/faq/support-mobile-remind-v1.md
@@ -5,7 +5,7 @@ css_include: ["main"]
 ---
 
 # What is the Remind mobile app
-[Overview of why you might want to download remind](../features/mobile-remind-v1.md)
+[Overview of why you might want to download remind]({{< ref "/features/mobile-remind-v1.md" >}})
 
 # Something wrong?
 Please [report your problem](https://github.com/learnalist/support/issues/new).

--- a/hugo/content/features/mobile-humble-plank-v1.md
+++ b/hugo/content/features/mobile-humble-plank-v1.md
@@ -28,3 +28,9 @@ Record your plank activity, alone or with friends
 
 # Give us feedback
 We would love to hear from you, [please create an issue on github](https://github.com/learnalist/support/issues/new).
+
+# Reference
+- [Spaced Repetition on wikipedia](https://en.wikipedia.org/wiki/Spaced_repetition)
+- [ridiculous on wiktionary](https://en.wiktionary.org/wiki/ridiculous)
+- [Privacy-Policy]({{< ref "/faq/privacy-policy.md" >}})
+- [Support]({{< ref "/faq/support-mobile-humble-plank-v1.md" >}})

--- a/hugo/content/features/mobile-humble-plank-v1.md
+++ b/hugo/content/features/mobile-humble-plank-v1.md
@@ -25,3 +25,6 @@ Record your plank activity, alone or with friends
 
 # On youtube
 - A little video https://youtu.be/E9EHonpn7CA
+
+# Give us feedback
+We would love to hear from you, [please create an issue on github](https://github.com/learnalist/support/issues/new).

--- a/hugo/content/features/mobile-remind-v1.md
+++ b/hugo/content/features/mobile-remind-v1.md
@@ -115,3 +115,6 @@ When you click sooner, you are helping us know to decrease the time until we sho
 # Reference
 - [Spaced Repetition on wikipedia](https://en.wikipedia.org/wiki/Spaced_repetition)
 - [ridiculous on wiktionary](https://en.wiktionary.org/wiki/ridiculous)
+
+# Give us feedback
+We would love to hear from you, [please create an issue on github](https://github.com/learnalist/support/issues/new).

--- a/hugo/content/features/mobile-remind-v1.md
+++ b/hugo/content/features/mobile-remind-v1.md
@@ -112,9 +112,11 @@ When you click sooner, you are helping us know to decrease the time until we sho
 - Tap on an entry
 - Click the red bin / trash can and it will be forever deleted
 
+# Give us feedback
+We would love to hear from you, [please create an issue on github](https://github.com/learnalist/support/issues/new).
+
 # Reference
 - [Spaced Repetition on wikipedia](https://en.wikipedia.org/wiki/Spaced_repetition)
 - [ridiculous on wiktionary](https://en.wiktionary.org/wiki/ridiculous)
-
-# Give us feedback
-We would love to hear from you, [please create an issue on github](https://github.com/learnalist/support/issues/new).
+- [Privacy-Policy]({{< ref "/faq/privacy-policy.md" >}})
+- [Support]({{< ref "/faq/support-mobile-remind-v1.md" >}})

--- a/hugo/content/user/welcome.md
+++ b/hugo/content/user/welcome.md
@@ -33,3 +33,8 @@ css_include: ["main"]
     - Find where localstorage is and clear it.
     - Goto [the frontpage](/) and hopefully it will fix itself.
 - A growing list of issues (feature requests and bugs) can be found [https://github.com/freshteapot/learnalist-api/issues](https://github.com/freshteapot/learnalist-api/issues).
+
+# Support
+- [Mobile Humble Plank](/faq/support-mobile-humble-plank-v1.md)
+- [Mobile Remind](/faq/support-mobile-remind-v1.md)
+- [Create new issue on github](https://github.com/learnalist/support/issues/new)

--- a/hugo/content/user/welcome.md
+++ b/hugo/content/user/welcome.md
@@ -35,6 +35,6 @@ css_include: ["main"]
 - A growing list of issues (feature requests and bugs) can be found [https://github.com/freshteapot/learnalist-api/issues](https://github.com/freshteapot/learnalist-api/issues).
 
 # Support
-- [Mobile Humble Plank](/faq/support-mobile-humble-plank-v1.md)
-- [Mobile Remind](/faq/support-mobile-remind-v1.md)
+- [Mobile Humble Plank]({{< ref "/faq/support-mobile-humble-plank-v1.md" >}})
+- [Mobile Remind]({{< ref "/faq/support-mobile-remind-v1.md" >}})
 - [Create new issue on github](https://github.com/learnalist/support/issues/new)

--- a/scripts/run-hugo.sh
+++ b/scripts/run-hugo.sh
@@ -50,7 +50,16 @@ kill -9 $(lsof -ti tcp:1234) >/dev/null 2>&1
 check_installed
 
 # Config setup
-_BIND="${LAL_BIND:-$(ipconfig getifaddr en0)}"
+_INTERFACE="${LAL_INTERFACE:-en0}"
+_BIND="${LAL_BIND:-$(ipconfig getifaddr $_INTERFACE)}"
+# Poor mans attempt to find the internet
+internetFound=$?
+if [[ $internetFound != 0 ]]; then
+	echo "Your internet can not be found on en0, you will need to manually fix this for now"
+	echo "LAL_INTERFACE=en7 make develop"
+	exit 1
+fi
+
 _BASEURL="http://${_BIND}:1313"
 _APISERVER="http://${_BIND}:1234"
 


### PR DESCRIPTION
# What
- Support page for mobile humble plank app
- Support page for mobile remind app
- Better linking from welcome.html to the respective links above.
- Able to run make develop with LAL_INTERFACE, to make it easier to work on a mac when not on wifi, ie via mobile internet